### PR TITLE
feat: Format option for decimal and hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,5 @@ Applying this, if we have a set size of 1000 different strings, the probability 
 Other features that are coming soon include the following:
 
 - Argument to toggle between CRC32a and CRC32b
-- Argument to toggle between hexadecimal and decimal output
 - CRC16 implementation (currently incomplete)
 - Docs that explain how CRC32 works in more detail

--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ Included is a 32-bit and a 16-bit CRC (cyclic redundancy checksum) function. Thi
 After installing and importing the package (npm and yarn entries coming soon), it can be used as follows
 
 ```js
-crc32(str, [usePolynomialDivision])
+crc32(str, [usePolynomialDivision], [format])
 ```
 
 Include a string to hash, and optionally elect to use polynomial division, which is set to `false` by default. Instead of polynomial division, the default is to use a pre-calculated lookup table, which is faster. This is also the implementation strategy used within the C and PHP source code.
+
+The last option defaults to `true`, making the output a hexadecimal value. If set to `false` the output will be in decimal format.
 
 
 ## Collision resistance

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JS CRC32 (and CRC16)
 
-![package image](assets/images/graph-image.png)
+<img src="/assets/images/graph-image.png" alt="package graph image" width="500">
 
 A Javascript CRC checksum or hashing implementation that yields the same result as C and PHP CRC functions.
 

--- a/index.js
+++ b/index.js
@@ -19,8 +19,7 @@ function crc32_polynomialDivision(str) {
         crc = (crc >>> 1) ^ (polynomial & mask);
     }
     }
-    // Handle conversion to hexadecimal string
-    return ((crc ^ 0xFFFFFFFF) >>> 0).toString(16).padStart(8, '0');
+    return (crc ^ 0xFFFFFFFF) >>> 0;
 }
 
 // Lookup table implementation (this is the default because it's faster, due to being a precalculated table)
@@ -31,15 +30,16 @@ function crc32_lookupTable(str) {
     crc = (crc >>> 8) ^ crc32Table[(crc ^ str.charCodeAt(i)) & 0xFF];
     }
 
-    return ((crc ^ 0xFFFFFFFF) >>> 0).toString(16).padStart(8, '0');
+    return (crc ^ 0xFFFFFFFF) >>> 0;
 }
 
 // Export complete crc32 function
-
-module.exports = function crc32(str, usePolynomialDivision = false) {
+module.exports = function crc32(str, usePolynomialDivision = false, hexFormat = true) {
+    let crc;
     if (usePolynomialDivision) {
-    return crc32_polynomialDivision(str);
+    crc = crc32_polynomialDivision(str);
     } else {
-    return crc32_lookupTable(str);
+    crc = crc32_lookupTable(str);
     }
+    return hexFormat ? crc.toString(16).padStart(8, '0') : crc.toString(10);
 }

--- a/test.js
+++ b/test.js
@@ -13,7 +13,7 @@ describe('crc32', function() {
       let result = crc32('foo', true, true);
       assert.equal(result, "8c736521");
     });
-    it('Return hex value for CRC32 of a string foo using a lookup table:', function() {
+    it('Return decimal value for CRC32 of a string foo using a lookup table:', function() {
       let result = crc32('foo', false, false);
       assert.equal(result, "2356372769");
     });

--- a/test.js
+++ b/test.js
@@ -5,12 +5,20 @@ const assert = require('assert');
 const crc32 = require('./index.js');
 
 describe('crc32', function() {
-    it('Return value for CRC32 of a string foo using a lookup table:', function() {
+    it('Return hex value for CRC32 of a string foo using a lookup table:', function() {
       let result = crc32('foo');
       assert.equal(result, "8c736521");
     });
-    it('Return value for CRC32 of a string foo using polynomial division:', function() {
-      let result = crc32('foo', true);
+    it('Return hex value for CRC32 of a string foo using polynomial division:', function() {
+      let result = crc32('foo', true, true);
       assert.equal(result, "8c736521");
+    });
+    it('Return hex value for CRC32 of a string foo using a lookup table:', function() {
+      let result = crc32('foo', false, false);
+      assert.equal(result, "2356372769");
+    });
+    it('Return decimal value for CRC32 of a string foo using polynomial division:', function() {
+      let result = crc32('foo', true, false);
+      assert.equal(result, "2356372769");
     });
   });


### PR DESCRIPTION
Adds a new argument to the main function which allows for the selection of output format. The default is still hexadecimal, but it's also possible to output in decimal format.